### PR TITLE
DUnitの学習（高根沢）

### DIFF
--- a/learning/DUnit/D5/DUnit_Test/Project1.dpr
+++ b/learning/DUnit/D5/DUnit_Test/Project1.dpr
@@ -1,0 +1,13 @@
+program Project1;
+
+uses
+  Forms,
+  Unit1 in 'Unit1.pas' {Form1};
+
+{$R *.RES}
+
+begin
+  Application.Initialize;
+  Application.CreateForm(TForm1, Form1);
+  Application.Run;
+end.

--- a/learning/DUnit/D5/DUnit_Test/Unit1.dfm
+++ b/learning/DUnit/D5/DUnit_Test/Unit1.dfm
@@ -1,0 +1,41 @@
+object Form1: TForm1
+  Left = 192
+  Top = 125
+  Width = 1305
+  Height = 675
+  Caption = 'Form1'
+  Color = clBtnFace
+  Font.Charset = SHIFTJIS_CHARSET
+  Font.Color = clWindowText
+  Font.Height = -12
+  Font.Name = '‚l‚r ‚oƒSƒVƒbƒN'
+  Font.Style = []
+  OldCreateOrder = False
+  PixelsPerInch = 96
+  TextHeight = 12
+  object Label1: TLabel
+    Left = 248
+    Top = 120
+    Width = 33
+    Height = 12
+    Caption = 'Label1'
+  end
+  object Button1: TButton
+    Left = 240
+    Top = 64
+    Width = 75
+    Height = 25
+    Caption = '+'
+    TabOrder = 0
+    OnClick = Button1Click
+  end
+  object Button2: TButton
+    Left = 368
+    Top = 64
+    Width = 75
+    Height = 25
+    Caption = '-'
+    TabOrder = 1
+    OnClick = Button2Click
+  end
+end

--- a/learning/DUnit/D5/DUnit_Test/Unit1.pas
+++ b/learning/DUnit/D5/DUnit_Test/Unit1.pas
@@ -1,4 +1,4 @@
-unit Unit1;
+unit Unit1;    // テスト対象ユニット
 
 interface
 

--- a/learning/DUnit/D5/DUnit_Test/Unit1.pas
+++ b/learning/DUnit/D5/DUnit_Test/Unit1.pas
@@ -1,0 +1,59 @@
+unit Unit1;
+
+interface
+
+uses
+  Windows, Messages, SysUtils, Classes, Graphics, Controls, Forms, Dialogs,
+  StdCtrls;
+
+type
+  TForm1 = class(TForm)
+    Button1: TButton;
+    Label1: TLabel;
+    Button2: TButton;
+    procedure Button1Click(Sender: TObject);
+    procedure Button2Click(Sender: TObject);
+  private
+    { Private êÈåæ }
+  public
+    { Public êÈåæ }
+    function CalcMy2Numbers_addition(a,b:Integer):Integer;
+    function CalcMy2Numbers_subtraction(a,b:Integer):Integer;
+  end;
+
+var
+  Form1: TForm1;
+
+implementation
+
+{$R *.DFM}
+
+{ TForm1 }
+
+function TForm1.CalcMy2Numbers_addition(a, b: Integer): Integer;
+var
+  Myavar : Integer;
+begin
+  Myavar := a + b;
+  result := Myavar;
+end;
+
+function TForm1.CalcMy2Numbers_subtraction(a, b: Integer): Integer;
+var
+  Myavar : Integer;
+begin
+  Myavar := a - b;
+  result := Myavar;
+end;
+
+procedure TForm1.Button1Click(Sender: TObject);
+begin
+  Label1.Caption := IntToStr(CalcMy2Numbers_addition(12,12));
+end;
+
+procedure TForm1.Button2Click(Sender: TObject);
+begin
+  Label1.Caption := IntToStr(CalcMy2Numbers_subtraction(12,2));
+end;
+
+end.

--- a/learning/DUnit/D5/DUnit_Test/dunit/Project1Tests.dpr
+++ b/learning/DUnit/D5/DUnit_Test/dunit/Project1Tests.dpr
@@ -1,0 +1,34 @@
+// Uncomment the following directive to create a console application
+// or leave commented to create a GUI application...
+// {$APPTYPE CONSOLE}
+
+program Project1Tests;
+
+uses
+  TestFramework {$IFDEF LINUX},
+  QForms,
+  QGUITestRunner {$ELSE},
+  Forms,
+  GUITestRunner {$ENDIF},
+  TextTestRunner,
+  Unit1 in '..\Unit1.pas' {Form1},
+  Unit1Tests in 'Unit1Tests.pas';
+
+//テスト対象のユニット これは手動で追加した
+
+{$R *.RES}
+
+begin
+  Application.Initialize;
+
+{$IFDEF LINUX}
+  QGUITestRunner.RunRegisteredTests;
+{$ELSE}
+  if System.IsConsole then
+    TextTestRunner.RunRegisteredTests
+  else
+    GUITestRunner.RunRegisteredTests;
+{$ENDIF}
+
+end.
+

--- a/learning/DUnit/D5/DUnit_Test/dunit/Project1Tests.dpr
+++ b/learning/DUnit/D5/DUnit_Test/dunit/Project1Tests.dpr
@@ -2,7 +2,7 @@
 // or leave commented to create a GUI application...
 // {$APPTYPE CONSOLE}
 
-program Project1Tests;
+program Project1Tests;              // テストプロジェクト
 
 uses
   TestFramework {$IFDEF LINUX},
@@ -11,10 +11,10 @@ uses
   Forms,
   GUITestRunner {$ENDIF},
   TextTestRunner,
-  Unit1 in '..\Unit1.pas' {Form1},
+  Unit1 in '..\Unit1.pas' {Form1},  //テスト対象のユニット これは手動で追加した
   Unit1Tests in 'Unit1Tests.pas';
 
-//テスト対象のユニット これは手動で追加した
+
 
 {$R *.RES}
 

--- a/learning/DUnit/D5/DUnit_Test/dunit/Unit1Tests.pas
+++ b/learning/DUnit/D5/DUnit_Test/dunit/Unit1Tests.pas
@@ -1,4 +1,4 @@
-unit Unit1Tests;
+unit Unit1Tests;         // テストモジュール
 
 interface
 
@@ -9,17 +9,17 @@ uses
 type
   TForm1Tests = class(TTestCase)
   private
-    FForm1: TForm1;
+    FForm1: TForm1;      //テスト対象ユニットのフォームを定義
 
   protected
 
-    procedure SetUp; override;
-    procedure TearDown; override;
+    procedure SetUp; override;      //テスト前の初期化
+    procedure TearDown; override;   //テスト後の破棄
 
   published
 
     // Test methods
-    procedure TestCalcMy2Numbers_addition;
+    procedure TestCalcMy2Numbers_addition;     //計算結果を判断するテストメソッド
     procedure TestCalcMy2Numbers_subtraction;
 
   end;
@@ -28,19 +28,22 @@ implementation
 
 { TForm1Tests }
 
+//テスト前の初期化
 procedure TForm1Tests.SetUp;
 begin
   inherited;
   FForm1 := TForm1.Create(nil);
 end;
 
+//テスト後の破棄
 procedure TForm1Tests.TearDown;
 begin
   inherited;
-  FForm1.Free;
+  FForm1.Free;       //テスト対象ユニットのフォームのインスタンスを破棄
   FForm1 := nil;
 end;
 
+//計算結果を判断するテストメソッド
 procedure TForm1Tests.TestCalcMy2Numbers_addition;
 var
   ReturnValue: Integer;
@@ -54,7 +57,7 @@ begin
   // TODO: メソッド結果の検証
 
 //  CheckNotEquals(24, ReturnValue, 'Bad! Value should not equal');
-  CheckEquals(24, ReturnValue, 'Bad! Value should not equal');
+  CheckEquals(24, ReturnValue, 'Bad! Value should not equal');  //計算結果が正しいかをチェック
 
   Status('Success');
 end;
@@ -77,6 +80,7 @@ begin
 
   Status('Success');
 end;
+
 initialization
 
   TestFramework.RegisterTest('Unit1Tests Suite',

--- a/learning/DUnit/D5/DUnit_Test/dunit/Unit1Tests.pas
+++ b/learning/DUnit/D5/DUnit_Test/dunit/Unit1Tests.pas
@@ -1,0 +1,86 @@
+unit Unit1Tests;
+
+interface
+
+uses
+  Unit1,
+  TestFrameWork;
+
+type
+  TForm1Tests = class(TTestCase)
+  private
+    FForm1: TForm1;
+
+  protected
+
+    procedure SetUp; override;
+    procedure TearDown; override;
+
+  published
+
+    // Test methods
+    procedure TestCalcMy2Numbers_addition;
+    procedure TestCalcMy2Numbers_subtraction;
+
+  end;
+
+implementation
+
+{ TForm1Tests }
+
+procedure TForm1Tests.SetUp;
+begin
+  inherited;
+  FForm1 := TForm1.Create(nil);
+end;
+
+procedure TForm1Tests.TearDown;
+begin
+  inherited;
+  FForm1.Free;
+  FForm1 := nil;
+end;
+
+procedure TForm1Tests.TestCalcMy2Numbers_addition;
+var
+  ReturnValue: Integer;
+  b: Integer;
+  a: Integer;
+begin
+  a := 12;
+  b := 12;
+  // TODO: メソッド呼び出しパラメータのセットアップ
+  ReturnValue := FForm1.CalcMy2Numbers_addition(a, b);
+  // TODO: メソッド結果の検証
+
+//  CheckNotEquals(24, ReturnValue, 'Bad! Value should not equal');
+  CheckEquals(24, ReturnValue, 'Bad! Value should not equal');
+
+  Status('Success');
+end;
+
+procedure TForm1Tests.TestCalcMy2Numbers_subtraction;
+var
+  ReturnValue: Integer;
+  b: Integer;
+  a: Integer;
+begin
+  a := 12;
+  b := 2;
+  // TODO: メソッド呼び出しパラメータのセットアップ
+  ReturnValue := FForm1.CalcMy2Numbers_subtraction(a, b);
+  // TODO: メソッド結果の検証
+
+  CheckNotEquals(12, ReturnValue, 'Bad! Value should not equal');
+  CheckEquals(10, ReturnValue, 'Bad! Value should not equal');
+//  CheckEquals(24, ReturnValue, 'Bad! Value should not equal');
+
+  Status('Success');
+end;
+initialization
+
+  TestFramework.RegisterTest('Unit1Tests Suite',
+    TForm1Tests.Suite);
+
+end.
+ 

--- a/learning/DUnit/D5/DUnit_Test/dunit/dunit.ini
+++ b/learning/DUnit/D5/DUnit_Test/dunit/dunit.ini
@@ -1,0 +1,28 @@
+[GUITestRunner Config]
+AutoSave=1
+Left=78
+Top=78
+Width=605
+Height=500
+Maximized=0
+UseRegistry=0
+ResultsPanel.Height=174
+ErrorMessage.Height=75
+ErrorMessage.Visible=1
+FailureList.ColumnWidth[0]=120
+FailureList.ColumnWidth[1]=100
+FailureList.ColumnWidth[2]=295
+FailureList.ColumnWidth[3]=62
+HideTestNodesOnOpen=0
+BreakOnFailures=0
+FailOnNoChecksExecuted=0
+FailOnMemoryLeaked=0
+IgnoreSetUpTearDownLeaks=0
+ReportMemoryLeakTypes=0
+SelectTestedNode=1
+WarnOnFailTestOverride=0
+PopupX=350
+PopupY=30
+
+[Tests.Project1Tests.exe.Unit1Tests Suite.TForm1Tests]
+

--- a/learning/DUnit/D5/DUnit_Test/dunit/dunit.ini
+++ b/learning/DUnit/D5/DUnit_Test/dunit/dunit.ini
@@ -25,4 +25,5 @@ PopupX=350
 PopupY=30
 
 [Tests.Project1Tests.exe.Unit1Tests Suite.TForm1Tests]
+TestCalcMy2Numbers_subtraction=0
 

--- a/learning/DUnit/EX7/Projects/Project1.dpr
+++ b/learning/DUnit/EX7/Projects/Project1.dpr
@@ -1,0 +1,14 @@
+program Project1;
+
+uses
+  Vcl.Forms,
+  Unit1 in 'Unit1.pas' {Form1};
+
+{$R *.res}
+
+begin
+  Application.Initialize;
+  Application.MainFormOnTaskbar := True;
+  Application.CreateForm(TForm1, Form1);
+  Application.Run;
+end.

--- a/learning/DUnit/EX7/Projects/Project1.dproj
+++ b/learning/DUnit/EX7/Projects/Project1.dproj
@@ -1,0 +1,462 @@
+﻿<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+    <PropertyGroup>
+        <ProjectGuid>{4C3899E3-D7C2-43E9-9A1C-CA273E7775FD}</ProjectGuid>
+        <ProjectVersion>16.1</ProjectVersion>
+        <FrameworkType>VCL</FrameworkType>
+        <MainSource>Project1.dpr</MainSource>
+        <Base>True</Base>
+        <Config Condition="'$(Config)'==''">Debug</Config>
+        <Platform Condition="'$(Platform)'==''">Win32</Platform>
+        <TargetedPlatforms>1</TargetedPlatforms>
+        <AppType>Application</AppType>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(Config)'=='Base' or '$(Base)'!=''">
+        <Base>true</Base>
+    </PropertyGroup>
+    <PropertyGroup Condition="('$(Platform)'=='Win32' and '$(Base)'=='true') or '$(Base_Win32)'!=''">
+        <Base_Win32>true</Base_Win32>
+        <CfgParent>Base</CfgParent>
+        <Base>true</Base>
+    </PropertyGroup>
+    <PropertyGroup Condition="('$(Platform)'=='Win64' and '$(Base)'=='true') or '$(Base_Win64)'!=''">
+        <Base_Win64>true</Base_Win64>
+        <CfgParent>Base</CfgParent>
+        <Base>true</Base>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(Config)'=='Debug' or '$(Cfg_1)'!=''">
+        <Cfg_1>true</Cfg_1>
+        <CfgParent>Base</CfgParent>
+        <Base>true</Base>
+    </PropertyGroup>
+    <PropertyGroup Condition="('$(Platform)'=='Win32' and '$(Cfg_1)'=='true') or '$(Cfg_1_Win32)'!=''">
+        <Cfg_1_Win32>true</Cfg_1_Win32>
+        <CfgParent>Cfg_1</CfgParent>
+        <Cfg_1>true</Cfg_1>
+        <Base>true</Base>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(Config)'=='Release' or '$(Cfg_2)'!=''">
+        <Cfg_2>true</Cfg_2>
+        <CfgParent>Base</CfgParent>
+        <Base>true</Base>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(Base)'!=''">
+        <SanitizedProjectName>Project1</SanitizedProjectName>
+        <Icon_MainIcon>$(BDS)\bin\delphi_PROJECTICON.ico</Icon_MainIcon>
+        <DCC_Namespace>System;Xml;Data;Datasnap;Web;Soap;Vcl;Vcl.Imaging;Vcl.Touch;Vcl.Samples;Vcl.Shell;$(DCC_Namespace)</DCC_Namespace>
+        <DCC_DcuOutput>.\$(Platform)\$(Config)</DCC_DcuOutput>
+        <DCC_ExeOutput>.\$(Platform)\$(Config)</DCC_ExeOutput>
+        <DCC_E>false</DCC_E>
+        <DCC_N>false</DCC_N>
+        <DCC_S>false</DCC_S>
+        <DCC_F>false</DCC_F>
+        <DCC_K>false</DCC_K>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(Base_Win32)'!=''">
+        <DCC_Namespace>Winapi;System.Win;Data.Win;Datasnap.Win;Web.Win;Soap.Win;Xml.Win;Bde;$(DCC_Namespace)</DCC_Namespace>
+        <DCC_UsePackage>FireDACSqliteDriver;FireDACDSDriver;DBXSqliteDriver;FireDACPgDriver;fmx;IndySystem;frxe21;TeeDB;tethering;vclib;DBXInterBaseDriver;DataSnapClient;DataSnapServer;DataSnapCommon;frx21;DataSnapProviderClient;DBXSybaseASEDriver;DbxCommonDriver;vclimg;dbxcds;DatasnapConnectorsFreePascal;MetropolisUILiveTile;vcldb;vcldsnap;fmxFireDAC;DBXDb2Driver;DBXOracleDriver;CustomIPTransport;vclribbon;dsnap;IndyIPServer;fmxase;vcl;IndyCore;DBXMSSQLDriver;IndyIPCommon;CloudService;FmxTeeUI;FireDACIBDriver;CodeSiteExpressPkg;DataSnapFireDAC;FireDACDBXDriver;soapserver;inetdbxpress;dsnapxml;FireDACInfxDriver;FireDACDb2Driver;TechnoXE7;adortl;FireDACASADriver;bindcompfmx;FireDACODBCDriver;RESTBackendComponents;emsclientfiredac;rtl;dbrtl;DbxClientDriver;FireDACCommon;bindcomp;inetdb;frxTee21;Tee;DBXOdbcDriver;frxDB21;vclFireDAC;xmlrtl;DataSnapNativeClient;svnui;ibxpress;IndyProtocols;DBXMySQLDriver;FireDACCommonDriver;bindengine;vclactnband;bindcompdbx;soaprtl;FMXTee;TeeUI;bindcompvcl;vclie;FireDACADSDriver;vcltouch;emsclient;VCLRESTComponents;FireDACMSSQLDriver;FireDAC;VclSmp;DBXInformixDriver;Intraweb;DataSnapConnectors;DataSnapServerMidas;dsnapcon;DBXFirebirdDriver;inet;fmxobj;FireDACMySQLDriver;soapmidas;vclx;svn;DBXSybaseASADriver;FireDACOracleDriver;fmxdae;RESTComponents;FireDACMSAccDriver;dbexpress;DataSnapIndy10ServerTransport;IndyIPClient;$(DCC_UsePackage)</DCC_UsePackage>
+        <VerInfo_Locale>1033</VerInfo_Locale>
+        <VerInfo_Keys>CompanyName=;FileDescription=;FileVersion=1.0.0.0;InternalName=;LegalCopyright=;LegalTrademarks=;OriginalFilename=;ProductName=;ProductVersion=1.0.0.0;Comments=</VerInfo_Keys>
+        <VerInfo_IncludeVerInfo>true</VerInfo_IncludeVerInfo>
+        <Manifest_File>$(BDS)\bin\default_app.manifest</Manifest_File>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(Base_Win64)'!=''">
+        <DCC_UsePackage>FireDACSqliteDriver;FireDACDSDriver;DBXSqliteDriver;FireDACPgDriver;fmx;IndySystem;TeeDB;tethering;vclib;DBXInterBaseDriver;DataSnapClient;DataSnapServer;DataSnapCommon;DataSnapProviderClient;DBXSybaseASEDriver;DbxCommonDriver;vclimg;dbxcds;DatasnapConnectorsFreePascal;MetropolisUILiveTile;vcldb;vcldsnap;fmxFireDAC;DBXDb2Driver;DBXOracleDriver;CustomIPTransport;vclribbon;dsnap;IndyIPServer;fmxase;vcl;IndyCore;DBXMSSQLDriver;IndyIPCommon;CloudService;FmxTeeUI;FireDACIBDriver;DataSnapFireDAC;FireDACDBXDriver;soapserver;inetdbxpress;dsnapxml;FireDACInfxDriver;FireDACDb2Driver;adortl;FireDACASADriver;bindcompfmx;FireDACODBCDriver;RESTBackendComponents;emsclientfiredac;rtl;dbrtl;DbxClientDriver;FireDACCommon;bindcomp;inetdb;Tee;DBXOdbcDriver;vclFireDAC;xmlrtl;DataSnapNativeClient;ibxpress;IndyProtocols;DBXMySQLDriver;FireDACCommonDriver;bindengine;vclactnband;bindcompdbx;soaprtl;FMXTee;TeeUI;bindcompvcl;vclie;FireDACADSDriver;vcltouch;emsclient;VCLRESTComponents;FireDACMSSQLDriver;FireDAC;VclSmp;DBXInformixDriver;Intraweb;DataSnapConnectors;DataSnapServerMidas;dsnapcon;DBXFirebirdDriver;inet;fmxobj;FireDACMySQLDriver;soapmidas;vclx;DBXSybaseASADriver;FireDACOracleDriver;fmxdae;RESTComponents;FireDACMSAccDriver;dbexpress;DataSnapIndy10ServerTransport;IndyIPClient;$(DCC_UsePackage)</DCC_UsePackage>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(Cfg_1)'!=''">
+        <DCC_Define>DEBUG;$(DCC_Define)</DCC_Define>
+        <DCC_DebugDCUs>true</DCC_DebugDCUs>
+        <DCC_Optimize>false</DCC_Optimize>
+        <DCC_GenerateStackFrames>true</DCC_GenerateStackFrames>
+        <DCC_DebugInfoInExe>true</DCC_DebugInfoInExe>
+        <DCC_RemoteDebug>true</DCC_RemoteDebug>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(Cfg_1_Win32)'!=''">
+        <DCC_RemoteDebug>false</DCC_RemoteDebug>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(Cfg_2)'!=''">
+        <DCC_LocalDebugSymbols>false</DCC_LocalDebugSymbols>
+        <DCC_Define>RELEASE;$(DCC_Define)</DCC_Define>
+        <DCC_SymbolReferenceInfo>0</DCC_SymbolReferenceInfo>
+        <DCC_DebugInformation>0</DCC_DebugInformation>
+    </PropertyGroup>
+    <ItemGroup>
+        <DelphiCompile Include="$(MainSource)">
+            <MainSource>MainSource</MainSource>
+        </DelphiCompile>
+        <DCCReference Include="Unit1.pas">
+            <Form>Form1</Form>
+            <FormType>dfm</FormType>
+        </DCCReference>
+        <BuildConfiguration Include="Release">
+            <Key>Cfg_2</Key>
+            <CfgParent>Base</CfgParent>
+        </BuildConfiguration>
+        <BuildConfiguration Include="Base">
+            <Key>Base</Key>
+        </BuildConfiguration>
+        <BuildConfiguration Include="Debug">
+            <Key>Cfg_1</Key>
+            <CfgParent>Base</CfgParent>
+        </BuildConfiguration>
+    </ItemGroup>
+    <ProjectExtensions>
+        <Borland.Personality>Delphi.Personality.12</Borland.Personality>
+        <Borland.ProjectType>Application</Borland.ProjectType>
+        <BorlandProject>
+            <Delphi.Personality>
+                <Source>
+                    <Source Name="MainSource">Project1.dpr</Source>
+                </Source>
+            </Delphi.Personality>
+            <Deployment>
+                <DeployFile LocalName="Win32\Debug\Project1.exe" Configuration="Debug" Class="ProjectOutput">
+                    <Platform Name="Win32">
+                        <RemoteName>Project1.exe</RemoteName>
+                        <Overwrite>true</Overwrite>
+                    </Platform>
+                </DeployFile>
+                <DeployClass Required="true" Name="DependencyPackage">
+                    <Platform Name="iOSDevice">
+                        <Operation>1</Operation>
+                        <Extensions>.dylib</Extensions>
+                    </Platform>
+                    <Platform Name="Win32">
+                        <Operation>0</Operation>
+                        <Extensions>.bpl</Extensions>
+                    </Platform>
+                    <Platform Name="OSX32">
+                        <RemoteDir>Contents\MacOS</RemoteDir>
+                        <Operation>1</Operation>
+                        <Extensions>.dylib</Extensions>
+                    </Platform>
+                    <Platform Name="iOSSimulator">
+                        <Operation>1</Operation>
+                        <Extensions>.dylib</Extensions>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="DependencyModule">
+                    <Platform Name="iOSDevice">
+                        <Operation>1</Operation>
+                        <Extensions>.dylib</Extensions>
+                    </Platform>
+                    <Platform Name="Win32">
+                        <Operation>0</Operation>
+                        <Extensions>.dll;.bpl</Extensions>
+                    </Platform>
+                    <Platform Name="OSX32">
+                        <RemoteDir>Contents\MacOS</RemoteDir>
+                        <Operation>1</Operation>
+                        <Extensions>.dylib</Extensions>
+                    </Platform>
+                    <Platform Name="iOSSimulator">
+                        <Operation>1</Operation>
+                        <Extensions>.dylib</Extensions>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="iPad_Launch2048">
+                    <Platform Name="iOSDevice">
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="iOSSimulator">
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="ProjectOSXInfoPList">
+                    <Platform Name="OSX32">
+                        <RemoteDir>Contents</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="ProjectiOSDeviceDebug">
+                    <Platform Name="iOSDevice">
+                        <RemoteDir>..\$(PROJECTNAME).app.dSYM\Contents\Resources\DWARF</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="Android_SplashImage470">
+                    <Platform Name="Android">
+                        <RemoteDir>res\drawable-normal</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="AndroidLibnativeX86File">
+                    <Platform Name="Android">
+                        <RemoteDir>library\lib\x86</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="ProjectiOSResource">
+                    <Platform Name="iOSDevice">
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="iOSSimulator">
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="ProjectOSXEntitlements">
+                    <Platform Name="OSX32">
+                        <RemoteDir>../</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="AndroidGDBServer">
+                    <Platform Name="Android">
+                        <RemoteDir>library\lib\armeabi-v7a</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="iPhone_Launch640">
+                    <Platform Name="iOSDevice">
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="iOSSimulator">
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="Android_SplashImage960">
+                    <Platform Name="Android">
+                        <RemoteDir>res\drawable-xlarge</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="Android_LauncherIcon96">
+                    <Platform Name="Android">
+                        <RemoteDir>res\drawable-xhdpi</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="iPhone_Launch320">
+                    <Platform Name="iOSDevice">
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="iOSSimulator">
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="Android_LauncherIcon144">
+                    <Platform Name="Android">
+                        <RemoteDir>res\drawable-xxhdpi</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="AndroidLibnativeMipsFile">
+                    <Platform Name="Android">
+                        <RemoteDir>library\lib\mips</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="AndroidSplashImageDef">
+                    <Platform Name="Android">
+                        <RemoteDir>res\drawable</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="DebugSymbols">
+                    <Platform Name="OSX32">
+                        <RemoteDir>Contents\MacOS</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="iOSSimulator">
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="Win32">
+                        <Operation>0</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="DependencyFramework">
+                    <Platform Name="OSX32">
+                        <RemoteDir>Contents\MacOS</RemoteDir>
+                        <Operation>1</Operation>
+                        <Extensions>.framework</Extensions>
+                    </Platform>
+                    <Platform Name="Win32">
+                        <Operation>0</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="Android_SplashImage426">
+                    <Platform Name="Android">
+                        <RemoteDir>res\drawable-small</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="ProjectiOSEntitlements">
+                    <Platform Name="iOSDevice">
+                        <RemoteDir>../</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="AdditionalDebugSymbols">
+                    <Platform Name="OSX32">
+                        <RemoteDir>Contents\MacOS</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="iOSSimulator">
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="Win32">
+                        <RemoteDir>Contents\MacOS</RemoteDir>
+                        <Operation>0</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="AndroidClassesDexFile">
+                    <Platform Name="Android">
+                        <RemoteDir>classes</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="ProjectiOSInfoPList">
+                    <Platform Name="iOSDevice">
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="iOSSimulator">
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="iPad_Launch1024">
+                    <Platform Name="iOSDevice">
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="iOSSimulator">
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="Android_DefaultAppIcon">
+                    <Platform Name="Android">
+                        <RemoteDir>res\drawable</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="ProjectOSXResource">
+                    <Platform Name="OSX32">
+                        <RemoteDir>Contents\Resources</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="ProjectiOSDeviceResourceRules">
+                    <Platform Name="iOSDevice">
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="iPad_Launch768">
+                    <Platform Name="iOSDevice">
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="iOSSimulator">
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Required="true" Name="ProjectOutput">
+                    <Platform Name="iOSDevice">
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="Android">
+                        <RemoteDir>library\lib\armeabi-v7a</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="Win32">
+                        <Operation>0</Operation>
+                    </Platform>
+                    <Platform Name="OSX32">
+                        <RemoteDir>Contents\MacOS</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="iOSSimulator">
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="AndroidLibnativeArmeabiFile">
+                    <Platform Name="Android">
+                        <RemoteDir>library\lib\armeabi</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="Android_SplashImage640">
+                    <Platform Name="Android">
+                        <RemoteDir>res\drawable-large</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="File">
+                    <Platform Name="iOSDevice">
+                        <Operation>0</Operation>
+                    </Platform>
+                    <Platform Name="Android">
+                        <Operation>0</Operation>
+                    </Platform>
+                    <Platform Name="Win32">
+                        <Operation>0</Operation>
+                    </Platform>
+                    <Platform Name="OSX32">
+                        <RemoteDir>Contents\MacOS</RemoteDir>
+                        <Operation>0</Operation>
+                    </Platform>
+                    <Platform Name="iOSSimulator">
+                        <Operation>0</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="iPhone_Launch640x1136">
+                    <Platform Name="iOSDevice">
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="iOSSimulator">
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="Android_LauncherIcon36">
+                    <Platform Name="Android">
+                        <RemoteDir>res\drawable-ldpi</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="AndroidSplashStyles">
+                    <Platform Name="Android">
+                        <RemoteDir>res\values</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="iPad_Launch1536">
+                    <Platform Name="iOSDevice">
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="iOSSimulator">
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="Android_LauncherIcon48">
+                    <Platform Name="Android">
+                        <RemoteDir>res\drawable-mdpi</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="Android_LauncherIcon72">
+                    <Platform Name="Android">
+                        <RemoteDir>res\drawable-hdpi</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="ProjectAndroidManifest">
+                    <Platform Name="Android">
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <ProjectRoot Platform="Android" Name="$(PROJECTNAME)"/>
+                <ProjectRoot Platform="iOSDevice" Name="$(PROJECTNAME).app"/>
+                <ProjectRoot Platform="Win32" Name="$(PROJECTNAME)"/>
+                <ProjectRoot Platform="OSX32" Name="$(PROJECTNAME).app"/>
+                <ProjectRoot Platform="iOSSimulator" Name="$(PROJECTNAME).app"/>
+                <ProjectRoot Platform="Win64" Name="$(PROJECTNAME)"/>
+            </Deployment>
+            <Platforms>
+                <Platform value="Win32">True</Platform>
+                <Platform value="Win64">False</Platform>
+            </Platforms>
+            <UnitTesting>
+                <TestProjectName>C:\Users\TECHNO\Documents\Embarcadero\Studio\Projects\Test\Project1Tests.dproj</TestProjectName>
+            </UnitTesting>
+        </BorlandProject>
+        <ProjectFileVersion>12</ProjectFileVersion>
+    </ProjectExtensions>
+    <Import Project="$(BDS)\Bin\CodeGear.Delphi.Targets" Condition="Exists('$(BDS)\Bin\CodeGear.Delphi.Targets')"/>
+    <Import Project="$(APPDATA)\Embarcadero\$(BDSAPPDATABASEDIR)\$(PRODUCTVERSION)\UserTools.proj" Condition="Exists('$(APPDATA)\Embarcadero\$(BDSAPPDATABASEDIR)\$(PRODUCTVERSION)\UserTools.proj')"/>
+    <Import Project="$(MSBuildProjectName).deployproj" Condition="Exists('$(MSBuildProjectName).deployproj')"/>
+</Project>

--- a/learning/DUnit/EX7/Projects/ProjectGroup1.groupproj
+++ b/learning/DUnit/EX7/Projects/ProjectGroup1.groupproj
@@ -1,0 +1,48 @@
+﻿<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+    <PropertyGroup>
+        <ProjectGuid>{35287525-E9F7-4293-A9E5-76BC49614656}</ProjectGuid>
+    </PropertyGroup>
+    <ItemGroup>
+        <Projects Include="Project1.dproj">
+            <Dependencies/>
+        </Projects>
+        <Projects Include="Test\Project1Tests.dproj">
+            <Dependencies/>
+        </Projects>
+    </ItemGroup>
+    <ProjectExtensions>
+        <Borland.Personality>Default.Personality.12</Borland.Personality>
+        <Borland.ProjectType/>
+        <BorlandProject>
+            <Default.Personality/>
+        </BorlandProject>
+    </ProjectExtensions>
+    <Target Name="Project1">
+        <MSBuild Projects="Project1.dproj"/>
+    </Target>
+    <Target Name="Project1:Clean">
+        <MSBuild Projects="Project1.dproj" Targets="Clean"/>
+    </Target>
+    <Target Name="Project1:Make">
+        <MSBuild Projects="Project1.dproj" Targets="Make"/>
+    </Target>
+    <Target Name="Project1Tests">
+        <MSBuild Projects="Test\Project1Tests.dproj"/>
+    </Target>
+    <Target Name="Project1Tests:Clean">
+        <MSBuild Projects="Test\Project1Tests.dproj" Targets="Clean"/>
+    </Target>
+    <Target Name="Project1Tests:Make">
+        <MSBuild Projects="Test\Project1Tests.dproj" Targets="Make"/>
+    </Target>
+    <Target Name="Build">
+        <CallTarget Targets="Project1;Project1Tests"/>
+    </Target>
+    <Target Name="Clean">
+        <CallTarget Targets="Project1:Clean;Project1Tests:Clean"/>
+    </Target>
+    <Target Name="Make">
+        <CallTarget Targets="Project1:Make;Project1Tests:Make"/>
+    </Target>
+    <Import Project="$(BDS)\Bin\CodeGear.Group.Targets" Condition="Exists('$(BDS)\Bin\CodeGear.Group.Targets')"/>
+</Project>

--- a/learning/DUnit/EX7/Projects/Test/Project1Tests.dpr
+++ b/learning/DUnit/EX7/Projects/Test/Project1Tests.dpr
@@ -1,0 +1,27 @@
+program Project1Tests;
+{
+
+  Delphi DUnit テスト プロジェクト
+  -------------------------
+  このプロジェクトには、DUnit テスト フレームワークと GUI/コンソール型テスト ランナーが含まれています。
+  プロジェクト オプションの条件定義エントリに "CONSOLE_TESTRUNNER" を追加すると、
+  コンソール型テスト ランナーを使用できます。それ以外の場合は、デフォルトで GUI 型テスト ランナーが
+  使用されます。
+
+}
+
+{$IFDEF CONSOLE_TESTRUNNER}
+{$APPTYPE CONSOLE}
+{$ENDIF}
+
+uses
+  DUnitTestRunner,
+  TestUnit1 in 'TestUnit1.pas',
+  Unit1 in '..\Unit1.pas';
+
+{$R *.RES}
+
+begin
+  DUnitTestRunner.RunRegisteredTests;
+end.
+

--- a/learning/DUnit/EX7/Projects/Test/Project1Tests.dproj
+++ b/learning/DUnit/EX7/Projects/Test/Project1Tests.dproj
@@ -1,0 +1,479 @@
+﻿<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+    <PropertyGroup>
+        <ProjectGuid>{39A18CED-9A1C-4846-9B57-61569D980573}</ProjectGuid>
+        <ProjectVersion>16.1</ProjectVersion>
+        <FrameworkType>None</FrameworkType>
+        <Base>True</Base>
+        <Config Condition="'$(Config)'==''">Debug</Config>
+        <Platform Condition="'$(Platform)'==''">Win32</Platform>
+        <TargetedPlatforms>1</TargetedPlatforms>
+        <AppType>Console</AppType>
+        <MainSource>Project1Tests.dpr</MainSource>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(Config)'=='Base' or '$(Base)'!=''">
+        <Base>true</Base>
+    </PropertyGroup>
+    <PropertyGroup Condition="('$(Platform)'=='OSX32' and '$(Base)'=='true') or '$(Base_OSX32)'!=''">
+        <Base_OSX32>true</Base_OSX32>
+        <CfgParent>Base</CfgParent>
+        <Base>true</Base>
+    </PropertyGroup>
+    <PropertyGroup Condition="('$(Platform)'=='Win32' and '$(Base)'=='true') or '$(Base_Win32)'!=''">
+        <Base_Win32>true</Base_Win32>
+        <CfgParent>Base</CfgParent>
+        <Base>true</Base>
+    </PropertyGroup>
+    <PropertyGroup Condition="('$(Platform)'=='Win64' and '$(Base)'=='true') or '$(Base_Win64)'!=''">
+        <Base_Win64>true</Base_Win64>
+        <CfgParent>Base</CfgParent>
+        <Base>true</Base>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(Config)'=='Debug' or '$(Cfg_1)'!=''">
+        <Cfg_1>true</Cfg_1>
+        <CfgParent>Base</CfgParent>
+        <Base>true</Base>
+    </PropertyGroup>
+    <PropertyGroup Condition="('$(Platform)'=='Win32' and '$(Cfg_1)'=='true') or '$(Cfg_1_Win32)'!=''">
+        <Cfg_1_Win32>true</Cfg_1_Win32>
+        <CfgParent>Cfg_1</CfgParent>
+        <Cfg_1>true</Cfg_1>
+        <Base>true</Base>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(Config)'=='Release' or '$(Cfg_2)'!=''">
+        <Cfg_2>true</Cfg_2>
+        <CfgParent>Base</CfgParent>
+        <Base>true</Base>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(Base)'!=''">
+        <DCC_Namespace>System;Xml;Data;Datasnap;Web;Soap;Vcl;Vcl.Imaging;Vcl.Touch;Vcl.Samples;Vcl.Shell;$(DCC_Namespace)</DCC_Namespace>
+        <DCC_Define>_CONSOLE_TESTRUNNER;$(DCC_Define)</DCC_Define>
+        <DCC_UnitSearchPath>$(BDS)\Source\DUnit\src;$(DCC_UnitSearchPath)</DCC_UnitSearchPath>
+        <DCC_DcuOutput>.</DCC_DcuOutput>
+        <DCC_ExeOutput>.\$(Platform)\$(Config)</DCC_ExeOutput>
+        <DCC_E>false</DCC_E>
+        <DCC_N>false</DCC_N>
+        <DCC_S>false</DCC_S>
+        <DCC_F>false</DCC_F>
+        <DCC_K>false</DCC_K>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(Base_OSX32)'!=''">
+        <DCC_UsePackage>FireDACSqliteDriver;FireDACDSDriver;DBXSqliteDriver;FireDACPgDriver;fmx;IndySystem;tethering;DBXInterBaseDriver;DataSnapClient;DataSnapServer;DataSnapCommon;DataSnapProviderClient;DbxCommonDriver;dbxcds;fmxFireDAC;DBXOracleDriver;CustomIPTransport;dsnap;IndyIPServer;fmxase;IndyCore;IndyIPCommon;CloudService;FmxTeeUI;FireDACIBDriver;DataSnapFireDAC;FireDACDBXDriver;soapserver;inetdbxpress;dsnapxml;FireDACASADriver;bindcompfmx;FireDACODBCDriver;RESTBackendComponents;emsclientfiredac;rtl;dbrtl;DbxClientDriver;FireDACCommon;bindcomp;inetdb;xmlrtl;DataSnapNativeClient;ibxpress;IndyProtocols;DBXMySQLDriver;FireDACCommonDriver;bindengine;bindcompdbx;soaprtl;FMXTee;emsclient;FireDACMSSQLDriver;FireDAC;DBXInformixDriver;DataSnapServerMidas;DBXFirebirdDriver;inet;fmxobj;FireDACMySQLDriver;soapmidas;DBXSybaseASADriver;FireDACOracleDriver;fmxdae;RESTComponents;dbexpress;DataSnapIndy10ServerTransport;IndyIPClient;$(DCC_UsePackage)</DCC_UsePackage>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(Base_Win32)'!=''">
+        <DCC_UsePackage>FireDACSqliteDriver;FireDACDSDriver;DBXSqliteDriver;FireDACPgDriver;fmx;IndySystem;frxe21;TeeDB;tethering;vclib;DBXInterBaseDriver;DataSnapClient;DataSnapServer;DataSnapCommon;frx21;DataSnapProviderClient;DBXSybaseASEDriver;DbxCommonDriver;vclimg;dbxcds;DatasnapConnectorsFreePascal;MetropolisUILiveTile;vcldb;vcldsnap;fmxFireDAC;DBXDb2Driver;DBXOracleDriver;CustomIPTransport;vclribbon;dsnap;IndyIPServer;fmxase;vcl;IndyCore;DBXMSSQLDriver;IndyIPCommon;CloudService;FmxTeeUI;FireDACIBDriver;CodeSiteExpressPkg;DataSnapFireDAC;FireDACDBXDriver;soapserver;inetdbxpress;dsnapxml;FireDACInfxDriver;FireDACDb2Driver;TechnoXE7;adortl;FireDACASADriver;bindcompfmx;FireDACODBCDriver;RESTBackendComponents;emsclientfiredac;rtl;dbrtl;DbxClientDriver;FireDACCommon;bindcomp;inetdb;frxTee21;Tee;DBXOdbcDriver;frxDB21;vclFireDAC;xmlrtl;DataSnapNativeClient;svnui;ibxpress;IndyProtocols;DBXMySQLDriver;FireDACCommonDriver;bindengine;vclactnband;bindcompdbx;soaprtl;FMXTee;TeeUI;bindcompvcl;vclie;FireDACADSDriver;vcltouch;emsclient;VCLRESTComponents;FireDACMSSQLDriver;FireDAC;VclSmp;DBXInformixDriver;Intraweb;DataSnapConnectors;DataSnapServerMidas;dsnapcon;DBXFirebirdDriver;inet;fmxobj;FireDACMySQLDriver;soapmidas;vclx;svn;DBXSybaseASADriver;FireDACOracleDriver;fmxdae;RESTComponents;FireDACMSAccDriver;dbexpress;DataSnapIndy10ServerTransport;IndyIPClient;$(DCC_UsePackage)</DCC_UsePackage>
+        <VerInfo_Locale>1033</VerInfo_Locale>
+        <VerInfo_Keys>CompanyName=;FileDescription=;FileVersion=1.0.0.0;InternalName=;LegalCopyright=;LegalTrademarks=;OriginalFilename=;ProductName=;ProductVersion=1.0.0.0;Comments=</VerInfo_Keys>
+        <DCC_Namespace>Winapi;System.Win;Data.Win;Datasnap.Win;Web.Win;Soap.Win;Xml.Win;Bde;$(DCC_Namespace)</DCC_Namespace>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(Base_Win64)'!=''">
+        <DCC_UsePackage>FireDACSqliteDriver;FireDACDSDriver;DBXSqliteDriver;FireDACPgDriver;fmx;IndySystem;TeeDB;tethering;vclib;DBXInterBaseDriver;DataSnapClient;DataSnapServer;DataSnapCommon;DataSnapProviderClient;DBXSybaseASEDriver;DbxCommonDriver;vclimg;dbxcds;DatasnapConnectorsFreePascal;MetropolisUILiveTile;vcldb;vcldsnap;fmxFireDAC;DBXDb2Driver;DBXOracleDriver;CustomIPTransport;vclribbon;dsnap;IndyIPServer;fmxase;vcl;IndyCore;DBXMSSQLDriver;IndyIPCommon;CloudService;FmxTeeUI;FireDACIBDriver;DataSnapFireDAC;FireDACDBXDriver;soapserver;inetdbxpress;dsnapxml;FireDACInfxDriver;FireDACDb2Driver;adortl;FireDACASADriver;bindcompfmx;FireDACODBCDriver;RESTBackendComponents;emsclientfiredac;rtl;dbrtl;DbxClientDriver;FireDACCommon;bindcomp;inetdb;Tee;DBXOdbcDriver;vclFireDAC;xmlrtl;DataSnapNativeClient;ibxpress;IndyProtocols;DBXMySQLDriver;FireDACCommonDriver;bindengine;vclactnband;bindcompdbx;soaprtl;FMXTee;TeeUI;bindcompvcl;vclie;FireDACADSDriver;vcltouch;emsclient;VCLRESTComponents;FireDACMSSQLDriver;FireDAC;VclSmp;DBXInformixDriver;Intraweb;DataSnapConnectors;DataSnapServerMidas;dsnapcon;DBXFirebirdDriver;inet;fmxobj;FireDACMySQLDriver;soapmidas;vclx;DBXSybaseASADriver;FireDACOracleDriver;fmxdae;RESTComponents;FireDACMSAccDriver;dbexpress;DataSnapIndy10ServerTransport;IndyIPClient;$(DCC_UsePackage)</DCC_UsePackage>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(Cfg_1)'!=''">
+        <DCC_Define>DEBUG;$(DCC_Define)</DCC_Define>
+        <DCC_DebugDCUs>true</DCC_DebugDCUs>
+        <DCC_Optimize>false</DCC_Optimize>
+        <DCC_GenerateStackFrames>true</DCC_GenerateStackFrames>
+        <DCC_DebugInfoInExe>true</DCC_DebugInfoInExe>
+        <DCC_RemoteDebug>true</DCC_RemoteDebug>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(Cfg_1_Win32)'!=''">
+        <DCC_RemoteDebug>false</DCC_RemoteDebug>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(Cfg_2)'!=''">
+        <DCC_LocalDebugSymbols>false</DCC_LocalDebugSymbols>
+        <DCC_Define>RELEASE;$(DCC_Define)</DCC_Define>
+        <DCC_SymbolReferenceInfo>0</DCC_SymbolReferenceInfo>
+        <DCC_DebugInformation>0</DCC_DebugInformation>
+    </PropertyGroup>
+    <ItemGroup>
+        <DelphiCompile Include="$(MainSource)">
+            <MainSource>MainSource</MainSource>
+        </DelphiCompile>
+        <DCCReference Include="TestUnit1.pas"/>
+        <DCCReference Include="..\Unit1.pas">
+            <FormType>dfm</FormType>
+        </DCCReference>
+        <BuildConfiguration Include="Release">
+            <Key>Cfg_2</Key>
+            <CfgParent>Base</CfgParent>
+        </BuildConfiguration>
+        <BuildConfiguration Include="Base">
+            <Key>Base</Key>
+        </BuildConfiguration>
+        <BuildConfiguration Include="Debug">
+            <Key>Cfg_1</Key>
+            <CfgParent>Base</CfgParent>
+        </BuildConfiguration>
+    </ItemGroup>
+    <ProjectExtensions>
+        <Borland.Personality>Delphi.Personality.12</Borland.Personality>
+        <Borland.ProjectType>Application</Borland.ProjectType>
+        <BorlandProject>
+            <Delphi.Personality>
+                <Source>
+                    <Source Name="MainSource">Project1Tests.dpr</Source>
+                </Source>
+            </Delphi.Personality>
+            <Deployment>
+                <DeployFile LocalName="$(BDS)\Redist\osx32\libcgunwind.1.0.dylib" Class="DependencyModule">
+                    <Platform Name="OSX32">
+                        <Overwrite>true</Overwrite>
+                    </Platform>
+                    <Platform Name="iOSSimulator">
+                        <Overwrite>true</Overwrite>
+                    </Platform>
+                </DeployFile>
+                <DeployFile LocalName="Win32\Debug\Project1Tests.exe" Configuration="Debug" Class="ProjectOutput">
+                    <Platform Name="Win32">
+                        <RemoteName>Project1Tests.exe</RemoteName>
+                        <Overwrite>true</Overwrite>
+                    </Platform>
+                </DeployFile>
+                <DeployClass Required="true" Name="DependencyPackage">
+                    <Platform Name="iOSDevice">
+                        <Operation>1</Operation>
+                        <Extensions>.dylib</Extensions>
+                    </Platform>
+                    <Platform Name="Win32">
+                        <Operation>0</Operation>
+                        <Extensions>.bpl</Extensions>
+                    </Platform>
+                    <Platform Name="OSX32">
+                        <RemoteDir>Contents\MacOS</RemoteDir>
+                        <Operation>1</Operation>
+                        <Extensions>.dylib</Extensions>
+                    </Platform>
+                    <Platform Name="iOSSimulator">
+                        <Operation>1</Operation>
+                        <Extensions>.dylib</Extensions>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="DependencyModule">
+                    <Platform Name="iOSDevice">
+                        <Operation>1</Operation>
+                        <Extensions>.dylib</Extensions>
+                    </Platform>
+                    <Platform Name="Win32">
+                        <Operation>0</Operation>
+                        <Extensions>.dll;.bpl</Extensions>
+                    </Platform>
+                    <Platform Name="OSX32">
+                        <RemoteDir>Contents\MacOS</RemoteDir>
+                        <Operation>1</Operation>
+                        <Extensions>.dylib</Extensions>
+                    </Platform>
+                    <Platform Name="iOSSimulator">
+                        <Operation>1</Operation>
+                        <Extensions>.dylib</Extensions>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="iPad_Launch2048">
+                    <Platform Name="iOSDevice">
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="iOSSimulator">
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="ProjectOSXInfoPList">
+                    <Platform Name="OSX32">
+                        <RemoteDir>Contents</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="ProjectiOSDeviceDebug">
+                    <Platform Name="iOSDevice">
+                        <RemoteDir>..\$(PROJECTNAME).app.dSYM\Contents\Resources\DWARF</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="Android_SplashImage470">
+                    <Platform Name="Android">
+                        <RemoteDir>res\drawable-normal</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="AndroidLibnativeX86File">
+                    <Platform Name="Android">
+                        <RemoteDir>library\lib\x86</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="ProjectiOSResource">
+                    <Platform Name="iOSDevice">
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="iOSSimulator">
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="ProjectOSXEntitlements">
+                    <Platform Name="OSX32">
+                        <RemoteDir>../</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="AndroidGDBServer">
+                    <Platform Name="Android">
+                        <RemoteDir>library\lib\armeabi-v7a</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="iPhone_Launch640">
+                    <Platform Name="iOSDevice">
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="iOSSimulator">
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="Android_SplashImage960">
+                    <Platform Name="Android">
+                        <RemoteDir>res\drawable-xlarge</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="Android_LauncherIcon96">
+                    <Platform Name="Android">
+                        <RemoteDir>res\drawable-xhdpi</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="iPhone_Launch320">
+                    <Platform Name="iOSDevice">
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="iOSSimulator">
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="Android_LauncherIcon144">
+                    <Platform Name="Android">
+                        <RemoteDir>res\drawable-xxhdpi</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="AndroidLibnativeMipsFile">
+                    <Platform Name="Android">
+                        <RemoteDir>library\lib\mips</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="AndroidSplashImageDef">
+                    <Platform Name="Android">
+                        <RemoteDir>res\drawable</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="DebugSymbols">
+                    <Platform Name="OSX32">
+                        <RemoteDir>Contents\MacOS</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="iOSSimulator">
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="Win32">
+                        <Operation>0</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="DependencyFramework">
+                    <Platform Name="OSX32">
+                        <RemoteDir>Contents\MacOS</RemoteDir>
+                        <Operation>1</Operation>
+                        <Extensions>.framework</Extensions>
+                    </Platform>
+                    <Platform Name="Win32">
+                        <Operation>0</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="Android_SplashImage426">
+                    <Platform Name="Android">
+                        <RemoteDir>res\drawable-small</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="ProjectiOSEntitlements">
+                    <Platform Name="iOSDevice">
+                        <RemoteDir>../</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="AdditionalDebugSymbols">
+                    <Platform Name="OSX32">
+                        <RemoteDir>Contents\MacOS</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="iOSSimulator">
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="Win32">
+                        <RemoteDir>Contents\MacOS</RemoteDir>
+                        <Operation>0</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="AndroidClassesDexFile">
+                    <Platform Name="Android">
+                        <RemoteDir>classes</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="ProjectiOSInfoPList">
+                    <Platform Name="iOSDevice">
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="iOSSimulator">
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="iPad_Launch1024">
+                    <Platform Name="iOSDevice">
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="iOSSimulator">
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="Android_DefaultAppIcon">
+                    <Platform Name="Android">
+                        <RemoteDir>res\drawable</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="ProjectOSXResource">
+                    <Platform Name="OSX32">
+                        <RemoteDir>Contents\Resources</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="ProjectiOSDeviceResourceRules">
+                    <Platform Name="iOSDevice">
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="iPad_Launch768">
+                    <Platform Name="iOSDevice">
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="iOSSimulator">
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Required="true" Name="ProjectOutput">
+                    <Platform Name="iOSDevice">
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="Android">
+                        <RemoteDir>library\lib\armeabi-v7a</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="Win32">
+                        <Operation>0</Operation>
+                    </Platform>
+                    <Platform Name="OSX32">
+                        <RemoteDir>Contents\MacOS</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="iOSSimulator">
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="AndroidLibnativeArmeabiFile">
+                    <Platform Name="Android">
+                        <RemoteDir>library\lib\armeabi</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="Android_SplashImage640">
+                    <Platform Name="Android">
+                        <RemoteDir>res\drawable-large</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="File">
+                    <Platform Name="iOSDevice">
+                        <Operation>0</Operation>
+                    </Platform>
+                    <Platform Name="Android">
+                        <Operation>0</Operation>
+                    </Platform>
+                    <Platform Name="Win32">
+                        <Operation>0</Operation>
+                    </Platform>
+                    <Platform Name="OSX32">
+                        <RemoteDir>Contents\MacOS</RemoteDir>
+                        <Operation>0</Operation>
+                    </Platform>
+                    <Platform Name="iOSSimulator">
+                        <Operation>0</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="iPhone_Launch640x1136">
+                    <Platform Name="iOSDevice">
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="iOSSimulator">
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="Android_LauncherIcon36">
+                    <Platform Name="Android">
+                        <RemoteDir>res\drawable-ldpi</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="AndroidSplashStyles">
+                    <Platform Name="Android">
+                        <RemoteDir>res\values</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="iPad_Launch1536">
+                    <Platform Name="iOSDevice">
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="iOSSimulator">
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="Android_LauncherIcon48">
+                    <Platform Name="Android">
+                        <RemoteDir>res\drawable-mdpi</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="Android_LauncherIcon72">
+                    <Platform Name="Android">
+                        <RemoteDir>res\drawable-hdpi</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="ProjectAndroidManifest">
+                    <Platform Name="Android">
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <ProjectRoot Platform="Android" Name="$(PROJECTNAME)"/>
+                <ProjectRoot Platform="iOSDevice" Name="$(PROJECTNAME).app"/>
+                <ProjectRoot Platform="Win32" Name="$(PROJECTNAME)"/>
+                <ProjectRoot Platform="OSX32" Name="$(PROJECTNAME).app"/>
+                <ProjectRoot Platform="iOSSimulator" Name="$(PROJECTNAME).app"/>
+                <ProjectRoot Platform="Win64" Name="$(PROJECTNAME)"/>
+            </Deployment>
+            <Platforms>
+                <Platform value="OSX32">False</Platform>
+                <Platform value="Win32">True</Platform>
+                <Platform value="Win64">False</Platform>
+            </Platforms>
+            <UnitTesting>
+                <TestFramework>DUnit / Delphi Win32</TestFramework>
+                <TestRunner>GUI</TestRunner>
+                <SourceProjectName>C:\Users\TECHNO\Documents\Embarcadero\Studio\Projects\Project1.dproj</SourceProjectName>
+            </UnitTesting>
+        </BorlandProject>
+        <ProjectFileVersion>12</ProjectFileVersion>
+    </ProjectExtensions>
+    <Import Project="$(BDS)\Bin\CodeGear.Delphi.Targets" Condition="Exists('$(BDS)\Bin\CodeGear.Delphi.Targets')"/>
+    <Import Project="$(APPDATA)\Embarcadero\$(BDSAPPDATABASEDIR)\$(PRODUCTVERSION)\UserTools.proj" Condition="Exists('$(APPDATA)\Embarcadero\$(BDSAPPDATABASEDIR)\$(PRODUCTVERSION)\UserTools.proj')"/>
+    <Import Project="$(MSBuildProjectName).deployproj" Condition="Exists('$(MSBuildProjectName).deployproj')"/>
+</Project>

--- a/learning/DUnit/EX7/Projects/Test/TestUnit1.pas
+++ b/learning/DUnit/EX7/Projects/Test/TestUnit1.pas
@@ -1,0 +1,67 @@
+unit TestUnit1;
+{
+
+  Delphi DUnit テスト ケース
+  ----------------------
+  このユニットには、テスト ケース ウィザードで生成されたスケルトン テスト ケース クラスが含まれています。
+  生成されたコードを正しくセットアップできるように修正し、テスト対象ユニットのメソッドを 
+  呼び出します。
+
+}
+
+interface
+
+uses
+  TestFramework, System.SysUtils, Vcl.Graphics, Vcl.StdCtrls, Winapi.Windows,
+  System.Variants, System.Classes, Vcl.Dialogs, Vcl.Controls, Vcl.Forms,
+  Winapi.Messages, Unit1, Vcl.Buttons;
+
+type
+  // クラスのテスト メソッド TForm1
+
+  TestTForm1 = class(TTestCase)
+  strict private
+    FForm1: TForm1;
+  public
+    procedure SetUp; override;
+    procedure TearDown; override;
+  published
+    procedure TestCalcMy2Numbers;
+  end;
+
+implementation
+
+procedure TestTForm1.SetUp;
+begin
+  FForm1 := TForm1.Create(nil);
+end;
+
+procedure TestTForm1.TearDown;
+begin
+  FForm1.Free;
+  FForm1 := nil;
+end;
+
+procedure TestTForm1.TestCalcMy2Numbers;
+var
+  ReturnValue: Integer;
+  b: Integer;
+  a: Integer;
+begin
+  a := 12;
+  b := 12;
+  // TODO: メソッド呼び出しパラメータのセットアップ
+  ReturnValue := FForm1.CalcMy2Numbers(a, b);
+  // TODO: メソッド結果の検証
+
+//  CheckNotEquals(24, ReturnValue, 'Bad! Value should not equal');
+  CheckEquals(24, ReturnValue, 'Bad! Value should not equal');
+
+  Status('Success');
+end;
+
+initialization
+  // テスト ケースをテスト ランナーに登録する
+  RegisterTest(TestTForm1.Suite);
+end.
+

--- a/learning/DUnit/EX7/Projects/Test/TestUnit1.pas
+++ b/learning/DUnit/EX7/Projects/Test/TestUnit1.pas
@@ -4,7 +4,7 @@ unit TestUnit1;
   Delphi DUnit テスト ケース
   ----------------------
   このユニットには、テスト ケース ウィザードで生成されたスケルトン テスト ケース クラスが含まれています。
-  生成されたコードを正しくセットアップできるように修正し、テスト対象ユニットのメソッドを 
+  生成されたコードを正しくセットアップできるように修正し、テスト対象ユニットのメソッドを
   呼び出します。
 
 }
@@ -26,7 +26,8 @@ type
     procedure SetUp; override;
     procedure TearDown; override;
   published
-    procedure TestCalcMy2Numbers;
+    procedure TestCalcMy2Numbers_addition;
+    procedure TestCalcMy2Numbers_subtraction;
   end;
 
 implementation
@@ -42,7 +43,7 @@ begin
   FForm1 := nil;
 end;
 
-procedure TestTForm1.TestCalcMy2Numbers;
+procedure TestTForm1.TestCalcMy2Numbers_addition;
 var
   ReturnValue: Integer;
   b: Integer;
@@ -51,11 +52,30 @@ begin
   a := 12;
   b := 12;
   // TODO: メソッド呼び出しパラメータのセットアップ
-  ReturnValue := FForm1.CalcMy2Numbers(a, b);
+  ReturnValue := FForm1.CalcMy2Numbers_addition(a, b);
   // TODO: メソッド結果の検証
 
 //  CheckNotEquals(24, ReturnValue, 'Bad! Value should not equal');
   CheckEquals(24, ReturnValue, 'Bad! Value should not equal');
+
+  Status('Success');
+end;
+
+procedure TestTForm1.TestCalcMy2Numbers_subtraction;
+var
+  ReturnValue: Integer;
+  b: Integer;
+  a: Integer;
+begin
+  a := 12;
+  b := 2;
+  // TODO: メソッド呼び出しパラメータのセットアップ
+  ReturnValue := FForm1.CalcMy2Numbers_subtraction(a, b);
+  // TODO: メソッド結果の検証
+
+//  CheckNotEquals(24, ReturnValue, 'Bad! Value should not equal');
+  CheckEquals(10, ReturnValue, 'Bad! Value should not equal');
+//  CheckEquals(24, ReturnValue, 'Bad! Value should not equal');
 
   Status('Success');
 end;

--- a/learning/DUnit/EX7/Projects/Test/TestUnit1.pas
+++ b/learning/DUnit/EX7/Projects/Test/TestUnit1.pas
@@ -73,7 +73,7 @@ begin
   ReturnValue := FForm1.CalcMy2Numbers_subtraction(a, b);
   // TODO: ƒƒ\ƒbƒhŒ‹‰Ê‚ÌŒŸØ
 
-//  CheckNotEquals(24, ReturnValue, 'Bad! Value should not equal');
+  CheckNotEquals(10, ReturnValue, 'Bad! Value should not equal');
   CheckEquals(10, ReturnValue, 'Bad! Value should not equal');
 //  CheckEquals(24, ReturnValue, 'Bad! Value should not equal');
 

--- a/learning/DUnit/EX7/Projects/Test/Win32/Debug/dunit.ini
+++ b/learning/DUnit/EX7/Projects/Test/Win32/Debug/dunit.ini
@@ -1,0 +1,26 @@
+[GUITestRunner Config]
+AutoSave=1
+Left=182
+Top=182
+Width=662
+Height=505
+Maximized=0
+UseRegistry=0
+ResultsPanel.Height=174
+ErrorMessage.Height=75
+ErrorMessage.Visible=1
+FailureList.ColumnWidth[0]=120
+FailureList.ColumnWidth[1]=100
+FailureList.ColumnWidth[2]=304
+FailureList.ColumnWidth[3]=110
+HideTestNodesOnOpen=0
+BreakOnFailures=0
+FailOnNoChecksExecuted=0
+FailOnMemoryLeaked=0
+IgnoreSetUpTearDownLeaks=0
+ReportMemoryLeakTypes=0
+SelectTestedNode=1
+WarnOnFailTestOverride=0
+PopupX=350
+PopupY=30
+

--- a/learning/DUnit/EX7/Projects/Test/Win32/Debug/dunit.ini
+++ b/learning/DUnit/EX7/Projects/Test/Win32/Debug/dunit.ini
@@ -24,3 +24,5 @@ WarnOnFailTestOverride=0
 PopupX=350
 PopupY=30
 
+[Tests.Project1Tests.exe.TestTForm1]
+

--- a/learning/DUnit/EX7/Projects/Unit1.dfm
+++ b/learning/DUnit/EX7/Projects/Unit1.dfm
@@ -25,8 +25,17 @@ object Form1: TForm1
     Top = 56
     Width = 75
     Height = 25
-    Caption = 'BitBtn1'
+    Caption = '+'
     TabOrder = 0
     OnClick = BitBtn1Click
+  end
+  object BitBtn2: TBitBtn
+    Left = 264
+    Top = 56
+    Width = 75
+    Height = 25
+    Caption = '-'
+    TabOrder = 1
+    OnClick = BitBtn2Click
   end
 end

--- a/learning/DUnit/EX7/Projects/Unit1.dfm
+++ b/learning/DUnit/EX7/Projects/Unit1.dfm
@@ -1,0 +1,32 @@
+object Form1: TForm1
+  Left = 0
+  Top = 0
+  Caption = 'Form1'
+  ClientHeight = 299
+  ClientWidth = 635
+  Color = clBtnFace
+  Font.Charset = DEFAULT_CHARSET
+  Font.Color = clWindowText
+  Font.Height = -11
+  Font.Name = 'Tahoma'
+  Font.Style = []
+  OldCreateOrder = False
+  PixelsPerInch = 96
+  TextHeight = 13
+  object Label1: TLabel
+    Left = 120
+    Top = 176
+    Width = 31
+    Height = 13
+    Caption = 'Label1'
+  end
+  object BitBtn1: TBitBtn
+    Left = 152
+    Top = 56
+    Width = 75
+    Height = 25
+    Caption = 'BitBtn1'
+    TabOrder = 0
+    OnClick = BitBtn1Click
+  end
+end

--- a/learning/DUnit/EX7/Projects/Unit1.pas
+++ b/learning/DUnit/EX7/Projects/Unit1.pas
@@ -1,0 +1,43 @@
+unit Unit1;
+
+interface
+
+uses
+  Winapi.Windows, Winapi.Messages, System.SysUtils, System.Variants, System.Classes, Vcl.Graphics,
+  Vcl.Controls, Vcl.Forms, Vcl.Dialogs, Vcl.StdCtrls, Vcl.Buttons;
+
+type
+  TForm1 = class(TForm)
+    BitBtn1: TBitBtn;
+    Label1: TLabel;
+    procedure BitBtn1Click(Sender: TObject);
+  private
+    { Private êÈåæ }
+  public
+    { Public êÈåæ }
+    function CalcMy2Numbers(a,b:Integer):Integer;
+  end;
+
+var
+  Form1: TForm1;
+
+implementation
+
+{$R *.dfm}
+
+{ TForm1 }
+
+procedure TForm1.BitBtn1Click(Sender: TObject);
+begin
+  Label1.Caption := IntToStr(CalcMy2Numbers(12,12));
+end;
+
+function TForm1.CalcMy2Numbers(a, b: Integer): Integer;
+var
+  Myavar : Integer;
+begin
+  Myavar := a + b;
+  result := Myavar;
+end;
+
+end.

--- a/learning/DUnit/EX7/Projects/Unit1.pas
+++ b/learning/DUnit/EX7/Projects/Unit1.pas
@@ -10,12 +10,15 @@ type
   TForm1 = class(TForm)
     BitBtn1: TBitBtn;
     Label1: TLabel;
+    BitBtn2: TBitBtn;
     procedure BitBtn1Click(Sender: TObject);
+    procedure BitBtn2Click(Sender: TObject);
   private
     { Private êÈåæ }
   public
     { Public êÈåæ }
-    function CalcMy2Numbers(a,b:Integer):Integer;
+    function CalcMy2Numbers_addition(a,b:Integer):Integer;
+    function CalcMy2Numbers_subtraction(a,b:Integer):Integer;
   end;
 
 var
@@ -29,14 +32,27 @@ implementation
 
 procedure TForm1.BitBtn1Click(Sender: TObject);
 begin
-  Label1.Caption := IntToStr(CalcMy2Numbers(12,12));
+  Label1.Caption := IntToStr(CalcMy2Numbers_addition(12,12));
 end;
 
-function TForm1.CalcMy2Numbers(a, b: Integer): Integer;
+procedure TForm1.BitBtn2Click(Sender: TObject);
+begin
+  Label1.Caption := IntToStr(CalcMy2Numbers_subtraction(12,2));
+end;
+
+function TForm1.CalcMy2Numbers_addition(a, b: Integer): Integer;
 var
   Myavar : Integer;
 begin
   Myavar := a + b;
+  result := Myavar;
+end;
+
+function TForm1.CalcMy2Numbers_subtraction(a, b: Integer): Integer;
+var
+  Myavar : Integer;
+begin
+  Myavar := a - b;
   result := Myavar;
 end;
 


### PR DESCRIPTION
ユニットテスト（DUnit）についての調査

- DUnitではなくDUnitXが推奨されているが、現在テクノではD5、XE7を使用して開発を行っている為DUnitXが使えない。
今回は池澤さんが調べてくれた
https://github.com/tecowl/AutoAnswer/issues/3465
https://github.com/tecowl/AutoAnswer/issues/3515
を参考にDUnitについて学習する。

- 先ずはD5ではDUnitが標準で使えないので、 https://sourceforge.net/projects/dunit/ からdunit-9.3.0.zipをダウンロードする。
https://github.com/tecowl/AutoAnswer/issues/3465#issuecomment-517228228
に従ってインストール設定を行ったが、うまくいかない。
`DUnitWizardProjectGroup50 内の, EPCDUnitWizard50.bpl を構築, インストールする。` の前に
EPCCommon50.bpl とEPCOTAUtils50.bpl を構築しておかないとエラーが出るようです。

- 次に基本的な使い方を知るために https://www.youtube.com/watch?v=nm_yq9jYckc のチュートリアルを行いました。
このチュートリアルは先ずXE7で行いました。
XE7ではウィザード通りに進めてすんなりできたのですが、D5で同じ事を試そうとしたところつまずきました。
D5ではテストプロジェクトを作成後に手動でテスト対象のユニットをプロジェクトにUsesしないとテストモジュールが作成されない。
（これが分からず、DUnitのインストール設定方法に不備があったのか？と悩んで時間を使ってしまった。
最終的に、池澤さんに確認して解決しました。違う方法があるのかもしれないが、池澤さんも現在この方法で作成しているとの事。）
ここで作成したコードを今回挙げました。

- データベースのユニットテストも試そうとしましたが
https://github.com/tecowl/AutoAnswer/issues/3515#issuecomment-525272177
で説明しているソースコードにデータベースのユニットテストが無いように見えます。
ソースコードの内容確認と実際にテストプログラムを起動して動作の確認のみ行いました。
データベースのユニットテストではXE7とD5で記述方法に違いがありそうなので、池澤さんとの再確認が必要です。

申し訳ありません。
当初はこの後、実際に使っているAAのソースの何かで簡単なテストプログラムを作ってみるところまでを予定していましたがまだ出来ていません。
もう一度、スケジュールの方調整しながら続きを行いたいと思います。